### PR TITLE
fix: names in lavaan_extract

### DIFF
--- a/R/lavaan_extract.R
+++ b/R/lavaan_extract.R
@@ -91,7 +91,10 @@ lavaan_extract <- function(fit,
   names(x) <- new.names
 
   if (!is.null(underscores_to_symbol) && operator == ":=") {
-    if (length(underscores_to_symbol) == 1 || length(underscores_to_symbol) == nrow(x)) {
+    if (length(underscores_to_symbol) == 1){
+      underscores_to_symbol <- rep(underscores_to_symbol, nrow(x))
+    }
+    if (length(underscores_to_symbol) == nrow(x)) {
       x[[1]] <- unlist(lapply(seq_along(underscores_to_symbol), function(i) {
         gsub("_", paste0(" ", underscores_to_symbol[[i]], " "), as.list(x[[1]])[[i]])
       }))

--- a/tests/testthat/_snaps/lavaan_defined.md
+++ b/tests/testthat/_snaps/lavaan_defined.md
@@ -3,11 +3,11 @@
     Code
       lavaan_defined(fit)
     Output
-         User-Defined Parameter                       Paths         SE         Z
-      30 ageyr → visual → speed   ageyr_visual*visual_speed 0.02808889 -3.198387
-      31 ageyr → visual → speed ageyr_visual*visual_textual 0.04191650 -3.461890
-      32 ageyr → visual → speed   grade_visual*visual_speed 0.07291514  4.257496
-      33 ageyr → visual → speed grade_visual*visual_textual 0.10134908  4.947490
+           User-Defined Parameter                       Paths         SE         Z
+      30   ageyr → visual → speed   ageyr_visual*visual_speed 0.02808889 -3.198387
+      31 ageyr → visual → textual ageyr_visual*visual_textual 0.04191650 -3.461890
+      32   grade → visual → speed   grade_visual*visual_speed 0.07291514  4.257496
+      33 grade → visual → textual grade_visual*visual_textual 0.10134908  4.947490
                     p           b   CI_lower    CI_upper          B CI_lower_B
       30 1.381987e-03 -0.08983914 -0.1448924 -0.03478593 -0.1508037 -0.2358595
       31 5.363956e-04 -0.14511033 -0.2272652 -0.06295550 -0.1534909 -0.2371048
@@ -23,22 +23,6 @@
 
     Code
       lavaan_defined(fit, nice_table = TRUE)
-    Output
-      a flextable object.
-      col_keys: `User-Defined Parameter`, `Paths`, `SE`, `Z`, `p`, `b`, `95% CI (b)`, `B`, `95% CI (B)` 
-      header has 1 row(s) 
-      body has 4 row(s) 
-      original dataset sample: 
-         User-Defined Parameter                       Paths         SE         Z
-      30 ageyr → visual → speed   ageyr_visual*visual_speed 0.02808889 -3.198387
-      31 ageyr → visual → speed ageyr_visual*visual_textual 0.04191650 -3.461890
-      32 ageyr → visual → speed   grade_visual*visual_speed 0.07291514  4.257496
-      33 ageyr → visual → speed grade_visual*visual_textual 0.10134908  4.947490
-                    p           b     95% CI (b)          B     95% CI (B)
-      30 1.381987e-03 -0.08983914 [-0.14, -0.03] -0.1508037 [-0.24, -0.07]
-      31 5.363956e-04 -0.14511033 [-0.23, -0.06] -0.1534909 [-0.24, -0.07]
-      32 2.067294e-05  0.31043593   [0.17, 0.45]  0.2477787   [0.15, 0.35]
-      33 7.517664e-07  0.50142352   [0.30, 0.70]  0.2521937   [0.16, 0.34]
 
 # nice_fit total effects
 
@@ -47,7 +31,7 @@
     Output
         User-Defined Parameter   Paths         SE        Z            p         b
       7                     ab     a*b 0.09204847 4.058692 4.934835e-05 0.3735964
-      8                     ab c+(a*b) 0.12471394 3.287131 1.012138e-03 0.4099510
+      8                  total c+(a*b) 0.12471394 3.287131 1.012138e-03 0.4099510
          CI_lower  CI_upper         B CI_lower_B CI_upper_B
       7 0.1931847 0.5540081 0.2845821  0.1638308  0.4053334
       8 0.1655162 0.6543859 0.3122748  0.1397572  0.4847923


### PR DESCRIPTION
Hi,
I think the `lavaan_extract` function only works as intended currently if you provide a list of replacement symbols rather than just one. Otherwise, the function overwrites all the paths in column one with whatever's in the first row as you can see in this screenshot from the vignette:

![image](https://github.com/rempsyc/lavaanExtra/assets/15876283/6fbb09ea-b372-4f41-9984-2871d6f53f80)

The current version works correctly only if you provide a vector of replacement characters, e.g.,
`lavaanExtra::lavaan_defined(fit,nice_table = TRUE, underscores_to_symbol = rep("->",4))`

With my fix, it displays correctly with the default syntax: 
`lavaanExtra::lavaan_defined(fit,nice_table = TRUE, underscores_to_symbol = "->")`

![image](https://github.com/rempsyc/lavaanExtra/assets/15876283/ab59a579-bde5-40fd-bae9-c2ddd349cda3)

Thanks!
Ethan